### PR TITLE
Remove .git directory from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .circleci
-.git
 *.dump
 _build
 deps


### PR DESCRIPTION
Because it is used when compile